### PR TITLE
Dispatch Cleanup

### DIFF
--- a/dispatch.lua
+++ b/dispatch.lua
@@ -6,12 +6,18 @@ g_managed_coroutines = {}
 g_managed_draw_coroutines = {}
 g_managed_predraw_coroutines = {}
 
-function co_delay(dt, callback)
-  return cocreate(function()
-    local start = time()
+-- note: only works when called within a coroutine!
+function delay(dt)
+  local start = time()
     while time() - start <= dt do
       yield()
     end
+end
+
+function co_delay(dt, callback)
+  return cocreate(function()
+    local start = time()
+    delay(dt)
 
     callback()
   end)
@@ -22,9 +28,7 @@ function co_animate(frames, dt, callback)
     for i=1,#frames do
       frame = frames[i]
       local start = time()
-      while time() - start <= dt do
-        yield()
-      end
+      delay(dt)
 
       callback(frame, i, i == #frames)
     end

--- a/tutorial.lua
+++ b/tutorial.lua
@@ -29,204 +29,129 @@ end
 function update_tutorial()
 end
 
+function tut_animation(frames, dt, end_wait, callback)
+  dispatch_coroutine(cocreate(function()
+    delay(0.22)
+    iter_delay(frames, dt, function(frame, i, is_last)
+      if #frame == 2 then
+        g_tutorial_state.x = frame[1]
+        g_tutorial_state.y = frame[2]
+      else
+        if frame[1] then
+          try_punch_puzzle_space(g_tutorial_state)
+
+          if is_game_won(g_tutorial_state) then
+            g_tutorial_state.is_win = true
+          end
+        else
+          mark_puzzle_space(g_tutorial_state)
+        end
+      end
+
+      if is_last then
+        dispatch_coroutine(co_delay(end_wait, function()
+          g_tutorial_state.message = ''
+          g_tutorial_state.row_runs_border = false
+          g_tutorial_state.col_runs_border = false
+          dispatch_coroutine(co_delay(.5, callback))
+        end))
+      end
+    end)
+  end))
+end
+
 function tut_show_movement()
   g_tutorial_state.message = 'use ⬅️⬆️➡️⬇️ to move the pencil'
 
-  dispatch_coroutine(co_delay(0.25, function()
-    dispatch_coroutine(co_animate({
-      { 2, 1 },
-      { 3, 1 },
-      { 3, 2 },
-      { 3, 3 },
-      { 2, 3 },
-      { 1, 3 },
-      { 1, 2 },
-    }, .4, function(pos, i, is_last)
-      g_tutorial_state.x = pos[1]
-      g_tutorial_state.y = pos[2]
-
-      if is_last then
-        dispatch_coroutine(co_delay(2, function()
-          g_tutorial_state.message = ''
-          dispatch_coroutine(co_delay(.5, tut_show_row_runs))
-        end))
-      end
-    end))
-  end))
+  tut_animation({
+    { 2, 1 },
+    { 3, 1 },
+    { 3, 2 },
+    { 3, 3 },
+    { 2, 3 },
+    { 1, 3 },
+    { 1, 2 },
+  }, 0.4, 2, tut_show_row_runs)
 end
 
 function tut_show_row_runs()
   g_tutorial_state.message = 'each number is a run of squares\nto punch. press ❎ to punch.'
   g_tutorial_state.row_runs_border = true
 
-  dispatch_coroutine(cocreate(function()
-    delay(0.5)
-
-    g_tutorial_state.x = 2
-    g_tutorial_state.y = 2
-    delay(0.5)
-
-    try_punch_puzzle_space(g_tutorial_state)
-    delay(0.5)
-
-    g_tutorial_state.x = 3
-    delay(0.5)
-
-    g_tutorial_state.x = 4
-    delay(0.5)
-
-    try_punch_puzzle_space(g_tutorial_state)
-    delay(1)
-    g_tutorial_state.message = ''
-    g_tutorial_state.row_runs_border = false
-    dispatch_coroutine(co_delay(.5, tut_show_col_runs))
-  end))
+  tut_animation({
+    { 2, 2 },
+    { true },
+    { 3, 2 },
+    { 4, 2 },
+    { true },
+  }, 0.4, 2, tut_show_col_runs)
 end
 
 function tut_show_col_runs()
   g_tutorial_state.message = 'same deal for columns.'
   g_tutorial_state.col_runs_border = true
 
-  dispatch_coroutine(cocreate(function()
-    delay(0.5)
-
-    g_tutorial_state.y = 3
-    delay(0.5)
-
-    g_tutorial_state.y = 4
-    delay(0.5)
-
-    g_tutorial_state.y = 5
-    delay(0.5)
-
-    try_punch_puzzle_space(g_tutorial_state)
-    delay(1)
-
-    g_tutorial_state.message = ''
-    g_tutorial_state.col_runs_border = false
-    dispatch_coroutine(co_delay(.5, tut_show_long_row))
-  end))
+  tut_animation({
+    { 4, 2 },
+    { 4, 3 },
+    { 4, 4 },
+    { 4, 5 },
+    { true },
+  }, 0.4, 2, tut_show_long_row)
 end
 
 function tut_show_long_row()
   g_tutorial_state.message = 'bigger numbers mean longer\nspans.'
 
-  dispatch_coroutine(cocreate(function()
-    delay(0.5)
-
-    g_tutorial_state.x = 3
-    delay(0.5)
-
-    try_punch_puzzle_space(g_tutorial_state)
-    delay(0.5)
-
-    g_tutorial_state.x = 2
-    delay(0.5)
-
-    try_punch_puzzle_space(g_tutorial_state)
-    delay(2)
-
-    g_tutorial_state.message = ''
-    dispatch_coroutine(co_delay(.5, tut_show_gaffe))
-  end))
+  tut_animation({
+    { 3, 5 },
+    { true },
+    { 2, 5 },
+    { true },
+  }, 0.4, 2, tut_show_gaffe)
 end
 
 function tut_show_gaffe()
   g_tutorial_state.message = 'careful! punching the wrong\nspace will cost a gaffe!'
 
-  dispatch_coroutine(cocreate(function()
-    delay(0.5)
-
-    g_tutorial_state.y = 4
-    delay(0.5)
-
-    try_punch_puzzle_space(g_tutorial_state)
-    delay(2)
-
-    g_tutorial_state.message = ''
-    dispatch_coroutine(co_delay(.5, tut_show_mark))
-  end))
+  tut_animation({
+    { 2, 4 },
+    { true },
+  }, 0.5, 2.5, tut_show_mark)
 end
 
 function tut_show_mark()
   g_tutorial_state.message = 'press 🅾️ to mark or unmark a\nspace. marking does not affect\nthe game. use it however you\nlike!'
 
-  dispatch_coroutine(cocreate(function()
-    delay(0.5)
-
-    g_tutorial_state.y = 3
-    delay(0.5)
-
-    g_tutorial_state.x = 2
-    delay(0.5)
-
-    g_tutorial_state.x = 1
-    delay(0.5)
-
-    mark_puzzle_space(g_tutorial_state)
-    delay(0.5)
-
-    g_tutorial_state.x = 2
-    delay(0.5)
-
-    mark_puzzle_space(g_tutorial_state)
-    delay(0.5)
-
-    g_tutorial_state.x = 3
-    delay(0.5)
-
-    mark_puzzle_space(g_tutorial_state)
-    delay(0.5)
-
-    g_tutorial_state.x = 4
-    delay(0.5)
-
-    mark_puzzle_space(g_tutorial_state)
-    delay(0.5)
-
-    g_tutorial_state.x = 5
-    delay(0.5)
-
-    mark_puzzle_space(g_tutorial_state)
-    delay(0.5)
-
-    delay(1)
-
-    g_tutorial_state.message = ''
-    dispatch_coroutine(co_delay(.5, tut_finish_puzzle))
-  end))
+  tut_animation({
+    { 2, 3 },
+    { 1, 3 },
+    { false },
+    { 2, 3 },
+    { false },
+    { 3, 3 },
+    { false },
+    { 4, 3 },
+    { false },
+    { 5, 3 },
+    { false },
+  }, 0.5, 3, tut_finish_puzzle)
 end
 
 function tut_finish_puzzle()
   g_tutorial_state.message = 'that\'s all. have fun!'
 
-  dispatch_coroutine(cocreate(function()
-    delay(0.5)
-    g_tutorial_state.y = 4
-    delay(0.5)
-
-    try_punch_puzzle_space(g_tutorial_state)
-    delay(0.5)
-
-    g_tutorial_state.x = 4
-    delay(0.5)
-
-    g_tutorial_state.x = 3
-    delay(0.5)
-
-    g_tutorial_state.x = 2
-    delay(0.5)
-
-    g_tutorial_state.x = 1
-    delay(0.5)
-
-    try_punch_puzzle_space(g_tutorial_state)
-    g_tutorial_state.is_win = true
-
-    delay(2)
-
+  tut_animation({
+    { 5, 4 },
+    { true },
+    { 4, 4 },
+    { 3, 4 },
+    { 2, 4 },
+    { 1, 4 },
+    { true },
+  }, 0.5, 2, function()
     transition_out(function()
       init_main_menu()
     end)
-  end))
+  end)
 end

--- a/tutorial.lua
+++ b/tutorial.lua
@@ -59,34 +59,27 @@ function tut_show_row_runs()
   g_tutorial_state.message = 'each number is a run of squares\nto punch. press ❎ to punch.'
   g_tutorial_state.row_runs_border = true
 
-  -- eeewwwww. Whatever; it works. Nested co_animate is causing issues.
-  dispatch_coroutine(co_delay(0.5, function()
-    dispatch_coroutine(co_delay(0.5, function()
-      g_tutorial_state.x = 2
-      g_tutorial_state.y = 2
+  dispatch_coroutine(cocreate(function()
+    delay(0.5)
 
-      dispatch_coroutine(co_delay(0.5, function()
-        try_punch_puzzle_space(g_tutorial_state)
+    g_tutorial_state.x = 2
+    g_tutorial_state.y = 2
+    delay(0.5)
 
-        dispatch_coroutine(co_delay(0.5, function()
-          g_tutorial_state.x = 3
+    try_punch_puzzle_space(g_tutorial_state)
+    delay(0.5)
 
-          dispatch_coroutine(co_delay(0.5, function()
-            g_tutorial_state.x = 4
+    g_tutorial_state.x = 3
+    delay(0.5)
 
-            dispatch_coroutine(co_delay(0.5, function()
-              try_punch_puzzle_space(g_tutorial_state)
+    g_tutorial_state.x = 4
+    delay(0.5)
 
-              dispatch_coroutine(co_delay(1, function()
-                g_tutorial_state.message = ''
-                g_tutorial_state.row_runs_border = false
-                dispatch_coroutine(co_delay(.5, tut_show_col_runs))
-              end))
-            end))
-          end))
-        end))
-      end))
-    end))
+    try_punch_puzzle_space(g_tutorial_state)
+    delay(1)
+    g_tutorial_state.message = ''
+    g_tutorial_state.row_runs_border = false
+    dispatch_coroutine(co_delay(.5, tut_show_col_runs))
   end))
 end
 
@@ -94,148 +87,146 @@ function tut_show_col_runs()
   g_tutorial_state.message = 'same deal for columns.'
   g_tutorial_state.col_runs_border = true
 
-  dispatch_coroutine(co_delay(0.5, function()
-    dispatch_coroutine(co_delay(0.5, function()
-      g_tutorial_state.y = 3
+  dispatch_coroutine(cocreate(function()
+    delay(0.5)
 
-      dispatch_coroutine(co_delay(0.5, function()
-        g_tutorial_state.y = 4
+    g_tutorial_state.y = 3
+    delay(0.5)
 
-          dispatch_coroutine(co_delay(0.5, function()
-            g_tutorial_state.y = 5
+    g_tutorial_state.y = 4
+    delay(0.5)
 
-          dispatch_coroutine(co_delay(0.5, function()
-            try_punch_puzzle_space(g_tutorial_state)
+    g_tutorial_state.y = 5
+    delay(0.5)
 
-            dispatch_coroutine(co_delay(1, function()
-              g_tutorial_state.message = ''
-              g_tutorial_state.col_runs_border = false
-              dispatch_coroutine(co_delay(.5, tut_show_long_row))
-            end))
-          end))
-        end))
-      end))
-    end))
+    try_punch_puzzle_space(g_tutorial_state)
+    delay(1)
+
+    g_tutorial_state.message = ''
+    g_tutorial_state.col_runs_border = false
+    dispatch_coroutine(co_delay(.5, tut_show_long_row))
   end))
 end
 
 function tut_show_long_row()
   g_tutorial_state.message = 'bigger numbers mean longer\nspans.'
 
-  dispatch_coroutine(co_delay(0.5, function()
-    dispatch_coroutine(co_delay(0.5, function()
-      g_tutorial_state.x = 3
+  dispatch_coroutine(cocreate(function()
+    delay(0.5)
 
-      dispatch_coroutine(co_delay(0.5, function()
-        try_punch_puzzle_space(g_tutorial_state)
+    g_tutorial_state.x = 3
+    delay(0.5)
 
-          dispatch_coroutine(co_delay(0.5, function()
-            g_tutorial_state.x = 2
+    try_punch_puzzle_space(g_tutorial_state)
+    delay(0.5)
 
-          dispatch_coroutine(co_delay(0.5, function()
-            try_punch_puzzle_space(g_tutorial_state)
+    g_tutorial_state.x = 2
+    delay(0.5)
 
-            dispatch_coroutine(co_delay(1, function()
-              g_tutorial_state.message = ''
-              dispatch_coroutine(co_delay(.5, tut_show_gaffe))
-            end))
-          end))
-        end))
-      end))
-    end))
+    try_punch_puzzle_space(g_tutorial_state)
+    delay(2)
+
+    g_tutorial_state.message = ''
+    dispatch_coroutine(co_delay(.5, tut_show_gaffe))
   end))
 end
 
 function tut_show_gaffe()
   g_tutorial_state.message = 'careful! punching the wrong\nspace will cost a gaffe!'
 
-  dispatch_coroutine(co_delay(0.5, function()
-    dispatch_coroutine(co_delay(0.5, function()
-      g_tutorial_state.y = 4
+  dispatch_coroutine(cocreate(function()
+    delay(0.5)
 
-      dispatch_coroutine(co_delay(0.5, function()
-        try_punch_puzzle_space(g_tutorial_state)
+    g_tutorial_state.y = 4
+    delay(0.5)
 
-        dispatch_coroutine(co_delay(2, function()
-          g_tutorial_state.message = ''
-          dispatch_coroutine(co_delay(.5, tut_show_mark))
-        end))
-      end))
-    end))
+    try_punch_puzzle_space(g_tutorial_state)
+    delay(2)
+
+    g_tutorial_state.message = ''
+    dispatch_coroutine(co_delay(.5, tut_show_mark))
   end))
 end
 
 function tut_show_mark()
-  g_tutorial_state.message = 'press 🅾️ to mark or unmark a\nspace. marking does not affect\nthe game.'
+  g_tutorial_state.message = 'press 🅾️ to mark or unmark a\nspace. marking does not affect\nthe game. use it however you\nlike!'
 
-  dispatch_coroutine(co_delay(0.5, function()
+  dispatch_coroutine(cocreate(function()
+    delay(0.5)
+
     g_tutorial_state.y = 3
+    delay(0.5)
 
-    dispatch_coroutine(co_delay(0.5, function()
-      mark_puzzle_space(g_tutorial_state)
+    g_tutorial_state.x = 2
+    delay(0.5)
 
-      dispatch_coroutine(co_delay(0.5, function()
-        g_tutorial_state.x = 3
+    g_tutorial_state.x = 1
+    delay(0.5)
 
-        dispatch_coroutine(co_delay(0.5, function()
-          mark_puzzle_space(g_tutorial_state)
+    mark_puzzle_space(g_tutorial_state)
+    delay(0.5)
 
-          dispatch_coroutine(co_delay(3, function()
-            g_tutorial_state.message = ''
-            dispatch_coroutine(co_delay(.5, tut_finish_puzzle))
-          end))
-        end))
-      end))
-    end))
+    g_tutorial_state.x = 2
+    delay(0.5)
+
+    mark_puzzle_space(g_tutorial_state)
+    delay(0.5)
+
+    g_tutorial_state.x = 3
+    delay(0.5)
+
+    mark_puzzle_space(g_tutorial_state)
+    delay(0.5)
+
+    g_tutorial_state.x = 4
+    delay(0.5)
+
+    mark_puzzle_space(g_tutorial_state)
+    delay(0.5)
+
+    g_tutorial_state.x = 5
+    delay(0.5)
+
+    mark_puzzle_space(g_tutorial_state)
+    delay(0.5)
+
+    delay(1)
+
+    g_tutorial_state.message = ''
+    dispatch_coroutine(co_delay(.5, tut_finish_puzzle))
   end))
 end
 
 function tut_finish_puzzle()
-  dispatch_coroutine(co_delay(0.5, function()
-    dispatch_coroutine(co_delay(0.5, function()
-      g_tutorial_state.x = 2
+  g_tutorial_state.message = 'that\'s all. have fun!'
 
-      dispatch_coroutine(co_delay(0.5, function()
-        g_tutorial_state.x = 1
+  dispatch_coroutine(cocreate(function()
+    delay(0.5)
+    g_tutorial_state.y = 4
+    delay(0.5)
 
-        dispatch_coroutine(co_delay(0.5, function()
-          g_tutorial_state.y = 4
+    try_punch_puzzle_space(g_tutorial_state)
+    delay(0.5)
 
-          dispatch_coroutine(co_delay(0.5, function()
-            try_punch_puzzle_space(g_tutorial_state)
+    g_tutorial_state.x = 4
+    delay(0.5)
 
-            dispatch_coroutine(co_delay(0.5, function()
-              g_tutorial_state.x = 2
+    g_tutorial_state.x = 3
+    delay(0.5)
 
-              dispatch_coroutine(co_delay(0.5, function()
-                g_tutorial_state.x = 3
+    g_tutorial_state.x = 2
+    delay(0.5)
 
-                dispatch_coroutine(co_delay(0.5, function()
-                  g_tutorial_state.x = 4
+    g_tutorial_state.x = 1
+    delay(0.5)
 
-                  dispatch_coroutine(co_delay(0.5, function()
-                    g_tutorial_state.x = 5
+    try_punch_puzzle_space(g_tutorial_state)
+    g_tutorial_state.is_win = true
 
-                    dispatch_coroutine(co_delay(0.5, function()
-                      try_punch_puzzle_space(g_tutorial_state)
-                      g_tutorial_state.is_win = true
+    delay(2)
 
-                      dispatch_coroutine(co_delay(.5, function()
-                        g_tutorial_state.message = 'that\'s all. have fun!'
-                        dispatch_coroutine(co_delay(4, function()
-                          transition_out(function()
-                            init_main_menu()
-                          end)
-                        end))
-                      end))
-                    end))
-                  end))
-                end))
-              end))
-            end))
-          end))
-        end))
-      end))
-    end))
+    transition_out(function()
+      init_main_menu()
+    end)
   end))
 end


### PR DESCRIPTION
The reason nested `co_animate` functions would fail is that I forgot to declare `frame` in the loop as `local`, so both coroutine instances were using the same variable. Anyway, this greatly cleans up the way dispatch works and vastly reduces code needed for the tutorial.